### PR TITLE
feat: Add ExceptionHandler and ResponseWrapper

### DIFF
--- a/src/main/java/com/shoesbox/global/common/ResponseWrapper.java
+++ b/src/main/java/com/shoesbox/global/common/ResponseWrapper.java
@@ -1,0 +1,33 @@
+package com.shoesbox.global.common;
+
+import com.shoesbox.global.exception.apierror.ApiError;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ResponseWrapper<T> {
+    private boolean success;
+    private T data;
+    private ApiError errorDetails;
+
+    public static <T> ResponseEntity<ResponseWrapper<T>> ok(T data) {
+        return ResponseEntity.ok(ResponseWrapper.<T>builder()
+                .success(true)
+                .data(data)
+                .errorDetails(null)
+                .build());
+    }
+
+    public static <T> ResponseWrapper<T> fail(ApiError apiError) {
+        return ResponseWrapper.<T>builder()
+                .success(false)
+                .data(null)
+                .errorDetails(apiError)
+                .build();
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/RestExceptionHandler.java
+++ b/src/main/java/com/shoesbox/global/exception/RestExceptionHandler.java
@@ -1,0 +1,327 @@
+package com.shoesbox.global.exception;
+
+import com.shoesbox.global.common.ResponseWrapper;
+import com.shoesbox.global.exception.apierror.ApiError;
+import com.shoesbox.global.exception.runtime.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Arrays;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * 컨트롤러 메서드에 @RequestParam 어노테이션이 있는데 url에는 해당 파라미터가 없을 때 발생
+     *
+     * @param ex      MissingServletRequestParameterException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(
+            HttpMediaTypeNotAcceptableException ex, HttpHeaders headers,
+            HttpStatus status, WebRequest request) {
+        String error =
+                ex.getMessage() + ", " + ex.getSupportedMediaTypes().stream().map(String::valueOf) + ", " + Arrays.toString(ex.getStackTrace());
+        var apiError = ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(error)
+                .ex(ex)
+                .build();
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * 컨트롤러 메서드에 @RequestParam 어노테이션이 있는데 url에는 해당 파라미터가 없을 때 발생
+     *
+     * @param ex      MissingServletRequestParameterException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex, HttpHeaders headers,
+            HttpStatus status, WebRequest request) {
+        String error = String.format(
+                "Missing request parameter '%s'",
+                ex.getParameterName());
+        var apiError = ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(error)
+                .ex(ex)
+                .build();
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * 요청의 ContentType이 x-www-form-urlencoded일 때, 컨트롤러 메서드의 매개변수가 Class 형태면 발생
+     *
+     * @param ex      HttpMediaTypeNotSupportedException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+            HttpMediaTypeNotSupportedException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        var builder = new StringBuilder();
+        builder.append(ex.getContentType());
+        builder.append(" 타입은 지원하지 않습니다. ");
+        ex.getSupportedMediaTypes().forEach(t -> builder.append(t).append(", "));
+        builder.append("을 사용해 주십시오.  ");
+        var apiError = ApiError.builder()
+                .status(UNSUPPORTED_MEDIA_TYPE)
+                .message(builder.substring(0, builder.length() - 2))
+                .ex(ex)
+                .build();
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * 컨트롤러에서 입력받는 값이 @Valid 검증을 통과하지 못했을 때 발생
+     *
+     * @param ex      the MethodArgumentNotValidException that is thrown when @Valid validation fails
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        var apiError = ApiError.builder()
+                .status(BAD_REQUEST)
+                .message("Validation error. 값이 올바르지 않습니다.")
+                .ex(ex)
+                .build();
+        apiError.addValidationErrors(ex.getBindingResult().getFieldErrors());
+        apiError.addValidationError(ex.getBindingResult().getGlobalErrors());
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * 요청으로 받은 JSON의 형식이 잘못 되었을 때(ex. key가 누락된 json) 발생
+     *
+     * @param ex      HttpMessageNotReadableException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        var servletWebRequest = (ServletWebRequest) request;
+        log.info("{} to {}", servletWebRequest.getHttpMethod(), servletWebRequest.getRequest().getServletPath());
+        var error = "Malformed JSON request." +
+                "정상적인 JSON 요청이 아닙니다. 형식이 올바른지 확인하십시오.";
+        var apiError = ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(error)
+                .ex(ex)
+                .build();
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * Spring이 반환된 객체의 프로퍼티를 가져올 수 없을 때 발생
+     *
+     * @param ex      HttpMessageNotWritableException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotWritable(HttpMessageNotWritableException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        var error = "Error writing JSON output. " +
+                "기본 생성자, Getters, Jackson 의존성이 있는지 확인하십시오.";
+        var apiError = ApiError.builder()
+                .status(INTERNAL_SERVER_ERROR)
+                .message(error)
+                .ex(ex)
+                .build();
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * 존재하지 않는 주소로 HTTP 요청을 보낼 때 발생
+     *
+     * @param ex      NoHandlerFoundException
+     * @param headers HttpHeaders
+     * @param status  HttpStatus
+     * @param request WebRequest
+     * @return the ApiError object
+     */
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(
+            NoHandlerFoundException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        var error = String.format(
+                "URL %s 에 대한 %s Method를 찾을 수 없습니다.",
+                ex.getRequestURL(),
+                ex.getHttpMethod());
+        var apiError = ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(error)
+                .ex(ex)
+                .build();
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+
+    /**
+     * 인자값에 오류가 있을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> IllegalArgument(IllegalArgumentException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * 회원가입 시 DB에 중복된 username, email, nickname이 이미 존재할 경우 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(DuplicateUserInfoException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handleDuplicateUser(DuplicateUserInfoException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * DB에서 리프레쉬 토큰을 찾을 수 없을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(RefreshTokenNotFoundException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handleRefreshTokenNotFound(RefreshTokenNotFoundException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(NOT_FOUND)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * JWT 토큰 유효성 검증에 실패했을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(InvalidJWTException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handleJWTVerification(InvalidJWTException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(UNAUTHORIZED)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * 로그인 아이디, 혹은 비밀번호가 틀렸을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(BadCredentialsException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handleBadCredentials(BadCredentialsException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(BAD_REQUEST)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * DB에서 유저 정보를 찾을 수 없을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(UsernameNotFoundException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handleUsernameNotFound(UsernameNotFoundException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(NOT_FOUND)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * DB에서 Post를 찾을 수 없을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(PostNotFoundException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handlePostNotFound(PostNotFoundException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(NOT_FOUND)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    /**
+     * 수정, 삭제 권한 등이 없을 때 발생
+     *
+     * @param ex the Exception
+     * @return the ApiError object
+     */
+    @ExceptionHandler(UnAuthorizedException.class)
+    protected ResponseEntity<ResponseWrapper<ApiError>> handleUnAuthorized(UnAuthorizedException ex) {
+        return buildResponseEntity(ApiError.builder()
+                .status(FORBIDDEN)
+                .message(ex.getMessage())
+                .ex(ex)
+                .build());
+    }
+
+    private ResponseEntity<ResponseWrapper<ApiError>> buildResponseEntity(ApiError apiError) {
+        return new ResponseEntity<>(ResponseWrapper.fail(apiError), apiError.getStatus());
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/apierror/ApiError.java
+++ b/src/main/java/com/shoesbox/global/exception/apierror/ApiError.java
@@ -1,0 +1,113 @@
+package com.shoesbox.global.exception.apierror;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.shoesbox.global.util.LowerCaseClassNameResolver;
+import lombok.Builder;
+import lombok.Data;
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+import javax.validation.ConstraintViolation;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Data
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.CUSTOM, property = "error", visible = true)
+@JsonTypeIdResolver(LowerCaseClassNameResolver.class)
+public class ApiError {
+
+    private HttpStatus status;
+    private int httpStatusCode;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss:SS")
+    private LocalDateTime timestamp;
+    private String message;
+    private String debugMessage;
+    private List<ApiSubError> subErrors;
+
+    private ApiError() {
+        timestamp = LocalDateTime.now();
+    }
+
+    // public ApiError(HttpStatus status) {
+    //     this();
+    //     this.status = status;
+    // }
+
+    // @Builder
+    // public ApiError(HttpStatus status, Throwable ex) {
+    //     this();
+    //     this.status = status;
+    //     this.message = "Unexpected error";
+    //     this.debugMessage = ex.getLocalizedMessage();
+    // }
+
+    @Builder
+    protected ApiError(HttpStatus status, String message, Throwable ex) {
+        this();
+        this.status = status;
+        this.httpStatusCode = status.value();
+        this.message = message;
+        this.debugMessage = ex.getLocalizedMessage();
+    }
+
+    private void addSubError(ApiSubError subError) {
+        if (subErrors == null) {
+            subErrors = new ArrayList<>();
+        }
+        subErrors.add(subError);
+    }
+
+    private void addValidationError(String object, String field, Object rejectedValue, String message) {
+        addSubError(new ApiValidationError(object, field, rejectedValue, message));
+    }
+
+    private void addValidationError(String object, String message) {
+        addSubError(new ApiValidationError(object, message));
+    }
+
+    private void addValidationError(FieldError fieldError) {
+        this.addValidationError(
+                fieldError.getObjectName(),
+                fieldError.getField(),
+                fieldError.getRejectedValue(),
+                fieldError.getDefaultMessage());
+    }
+
+    public void addValidationErrors(List<FieldError> fieldErrors) {
+        fieldErrors.forEach(this::addValidationError);
+    }
+
+    private void addValidationError(ObjectError objectError) {
+        this.addValidationError(
+                objectError.getObjectName(),
+                objectError.getDefaultMessage());
+    }
+
+    public void addValidationError(List<ObjectError> globalErrors) {
+        globalErrors.forEach(this::addValidationError);
+    }
+
+    /**
+     * Utility method for adding error of ConstraintViolation. Usually when a @Validated validation fails.
+     *
+     * @param cv the ConstraintViolation
+     */
+    private void addValidationError(ConstraintViolation<?> cv) {
+        this.addValidationError(
+                cv.getRootBeanClass().getSimpleName(),
+                ((PathImpl) cv.getPropertyPath()).getLeafNode().asString(),
+                cv.getInvalidValue(),
+                cv.getMessage());
+    }
+
+    public void addValidationErrors(Set<ConstraintViolation<?>> constraintViolations) {
+        constraintViolations.forEach(this::addValidationError);
+    }
+
+}

--- a/src/main/java/com/shoesbox/global/exception/apierror/ApiSubError.java
+++ b/src/main/java/com/shoesbox/global/exception/apierror/ApiSubError.java
@@ -1,0 +1,5 @@
+package com.shoesbox.global.exception.apierror;
+
+public abstract class ApiSubError {
+
+}

--- a/src/main/java/com/shoesbox/global/exception/apierror/ApiValidationError.java
+++ b/src/main/java/com/shoesbox/global/exception/apierror/ApiValidationError.java
@@ -1,0 +1,20 @@
+package com.shoesbox.global.exception.apierror;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor
+public class ApiValidationError extends ApiSubError {
+    private String object;
+    private String field;
+    private Object rejectedValue;
+    private String message;
+
+    ApiValidationError(String object, String message) {
+        this.object = object;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/runtime/DuplicateUserInfoException.java
+++ b/src/main/java/com/shoesbox/global/exception/runtime/DuplicateUserInfoException.java
@@ -1,0 +1,14 @@
+package com.shoesbox.global.exception.runtime;
+
+/**
+ * 회원가입 시 DB에 username, email, nickname이 이미 존재할 경우 발생
+ */
+public class DuplicateUserInfoException extends RuntimeException {
+    public DuplicateUserInfoException(String message) {
+        super(message);
+    }
+
+    public DuplicateUserInfoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/runtime/InvalidJWTException.java
+++ b/src/main/java/com/shoesbox/global/exception/runtime/InvalidJWTException.java
@@ -1,0 +1,14 @@
+package com.shoesbox.global.exception.runtime;
+
+/**
+ * JWT 토큰 유효성 검증에 실패했을 때 발생
+ */
+public class InvalidJWTException extends RuntimeException {
+    public InvalidJWTException(String message) {
+        this(message, null);
+    }
+
+    public InvalidJWTException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/runtime/PostNotFoundException.java
+++ b/src/main/java/com/shoesbox/global/exception/runtime/PostNotFoundException.java
@@ -1,0 +1,14 @@
+package com.shoesbox.global.exception.runtime;
+
+/**
+ * DB에서 Post를 찾을 수 없을 때 발생
+ */
+public class PostNotFoundException extends RuntimeException {
+    public PostNotFoundException(String message) {
+        super(message);
+    }
+
+    public PostNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/runtime/RefreshTokenNotFoundException.java
+++ b/src/main/java/com/shoesbox/global/exception/runtime/RefreshTokenNotFoundException.java
@@ -1,0 +1,14 @@
+package com.shoesbox.global.exception.runtime;
+
+/**
+ * db에서 리프레쉬 토큰을 찾을 수 없을 때 발생
+ */
+public class RefreshTokenNotFoundException extends RuntimeException {
+    public RefreshTokenNotFoundException(String message) {
+        this(message, null);
+    }
+
+    public RefreshTokenNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoesbox/global/exception/runtime/UnAuthorizedException.java
+++ b/src/main/java/com/shoesbox/global/exception/runtime/UnAuthorizedException.java
@@ -1,0 +1,14 @@
+package com.shoesbox.global.exception.runtime;
+
+/**
+ * 수정, 삭제 권한 등이 없을 때 발생
+ */
+public class UnAuthorizedException extends RuntimeException {
+    public UnAuthorizedException(String message) {
+        super(message);
+    }
+
+    public UnAuthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/shoesbox/global/util/LowerCaseClassNameResolver.java
+++ b/src/main/java/com/shoesbox/global/util/LowerCaseClassNameResolver.java
@@ -1,0 +1,21 @@
+package com.shoesbox.global.util;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+public class LowerCaseClassNameResolver extends TypeIdResolverBase {
+    @Override
+    public String idFromValue(Object value) {
+        return value.getClass().getSimpleName().toLowerCase();
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> suggestedType) {
+        return idFromValue(value);
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        return JsonTypeInfo.Id.CUSTOM;
+    }
+}


### PR DESCRIPTION
커스텀 예외 목록:
DuplicateUserInfoException
InvalidJWTException
PostNotFoundException
RefreshTokenNotFoundException
UnAuthorizedException

ApiError는 예외 메시지를 일관된 형태로 반환하기 위한 래퍼 클래스

ResponseWrapper는 api 응답을 일관된 형태로 반환하기 위한 래퍼 클래스

ResponseWrapper 사용법:

Controller의 반환값은
ResponseEntity<ResponseWrapper<반환할 객체타입>>
return 값은
ResponseWrapper.ok(반환할 객체);

Resolves: #8