### PR TITLE
refactor: Refactor coupling

### DIFF
--- a/src/main/java/com/shoesbox/domain/comment/Comment.java
+++ b/src/main/java/com/shoesbox/domain/comment/Comment.java
@@ -3,6 +3,8 @@ package com.shoesbox.domain.comment;
 import com.shoesbox.domain.member.Member;
 import com.shoesbox.domain.post.Post;
 import com.shoesbox.global.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +12,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "comment")
 public class Comment extends BaseTimeEntity {
     @Id
@@ -40,9 +42,10 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "post_id", updatable = false, insertable = false)
     private Long postId;
 
-    public Comment(CommentRequestDto commentRequestDto, Member member, Post post) {
-        this.nickname = commentRequestDto.getNickname();
-        this.content = commentRequestDto.getContent();
+    @Builder
+    private Comment(String nickname, String content, Member member, Post post) {
+        this.nickname = nickname;
+        this.content = content;
         this.member = member;
         this.post = post;
     }

--- a/src/main/java/com/shoesbox/domain/comment/CommentController.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentController.java
@@ -23,7 +23,9 @@ public class CommentController {
     public ResponseEntity<Object> createComment(@PathVariable long postId,
                                                 @Valid @RequestBody CommentRequestDto commentRequestDto) {
         long currentMemberId = SecurityUtil.getCurrentMemberIdByLong();
-        return ResponseHandler.ok(commentService.createComment(currentMemberId, postId, commentRequestDto));
+        String currentMemberNickname = SecurityUtil.getCurrentMemberNickname();
+        return ResponseHandler.ok(commentService.createComment(
+                currentMemberNickname, commentRequestDto.getContent(), currentMemberId, postId));
     }
 
     @PutMapping("/{commentId}")

--- a/src/main/java/com/shoesbox/domain/comment/CommentRequestDto.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentRequestDto.java
@@ -15,9 +15,6 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class CommentRequestDto {
-    long memberId;
-    @NotBlank(message = "닉네임 입력하지 않음")
-    String nickname;
     @NotBlank(message = "내용 입력하지 않음")
     String content;
 }

--- a/src/main/java/com/shoesbox/domain/comment/CommentResponseDto.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentResponseDto.java
@@ -1,23 +1,19 @@
 package com.shoesbox.domain.comment;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 
 @Getter
+@Builder
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class CommentResponseDto {
-    Long commentId;
+    long commentId;
     String nickname;
     String content;
-    Long postId;
-    Long memberId;
-
-    public CommentResponseDto(Comment comment) {
-        this.commentId = comment.getId();
-        this.nickname = comment.getNickname();
-        this.content = comment.getContent();
-        this.postId = comment.getPostId();
-        this.memberId = comment.getMemberId();
-    }
+    long postId;
+    long memberId;
+    String createdAt;
+    String modifiedAt;
 }

--- a/src/main/java/com/shoesbox/domain/comment/CommentService.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentService.java
@@ -65,8 +65,7 @@ public class CommentService {
                 .orElseThrow(
                         () -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
 
-        Post post = comment.getPost();
-        if (post.getMemberId() != currentMemberId) {
+        if (comment.getMemberId() != currentMemberId) {
             throw new UnAuthorizedException("본인이 작성한 댓글만 수정 가능합니다.");
         }
 

--- a/src/main/java/com/shoesbox/domain/member/MemberService.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberService.java
@@ -141,8 +141,10 @@ public class MemberService {
 
         // 3. 리프레쉬 토큰 저장소에서 userId(PK) 를 기반으로 토큰 가져옴
         RefreshToken savedRefreshToken =
-                refreshTokenRepository.findById(userId).orElseThrow(() -> new RefreshTokenNotFoundException("로그아웃 된 " +
-                        "사용자입니다."));
+                refreshTokenRepository.findById(userId)
+                        .orElseThrow(
+                                () -> new RefreshTokenNotFoundException("로그아웃 된 사용자입니다.")
+                        );
 
         // 4. Refresh Token 일치하는지 검사
         if (!savedRefreshToken.getTokenValue().equals(tokenRequestDto.getRefreshToken())) {

--- a/src/main/java/com/shoesbox/domain/post/Post.java
+++ b/src/main/java/com/shoesbox/domain/post/Post.java
@@ -5,7 +5,6 @@ import com.shoesbox.domain.member.Member;
 import com.shoesbox.global.common.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
@@ -14,7 +13,6 @@ import java.util.List;
 
 
 @Getter
-@NoArgsConstructor
 @Entity
 @Table(name = "post")
 public class Post extends BaseTimeEntity {
@@ -33,16 +31,16 @@ public class Post extends BaseTimeEntity {
     private String author;
 
     @Column(nullable = false)
-    private int createdYear;
+    private final int createdYear;
 
     @Column(nullable = false)
-    private int createdMonth;
+    private final int createdMonth;
 
     @Column(nullable = false)
-    private int createdDay;
+    private final int createdDay;
 
-    @Column
-    private String images;
+    // @Column
+    // private List<MultipartFile> images;
 
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
@@ -56,16 +54,20 @@ public class Post extends BaseTimeEntity {
             cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> comments;
 
-    @Builder
-    private Post(String title, String content, String author, String images, Member member) {
-        this.title = title;
-        this.content = content;
-        this.author = author;
-        this.images = images;
-        this.member = member;
+    protected Post() {
         this.createdYear = LocalDate.now().getYear();
         this.createdMonth = LocalDate.now().getMonthValue();
         this.createdDay = LocalDate.now().getDayOfMonth();
+    }
+
+    @Builder
+    private Post(long id, String title, String content, String author, Member member) {
+        this();
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.member = member;
     }
 
 

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -18,10 +18,10 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public PostResponseDto createPost(@RequestBody PostRequestDto postRequestDto) {
+    public ResponseEntity<Object> createPost(@RequestBody PostRequestDto postRequestDto) {
         long memberId = SecurityUtil.getCurrentMemberIdByLong();
         String nickname = SecurityUtil.getCurrentMemberNickname();
-        return this.postService.createPost(nickname, memberId, postRequestDto);
+        return ResponseHandler.ok(postService.createPost(nickname, memberId, postRequestDto));
     }
 
     @GetMapping

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -10,8 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +35,6 @@ public class PostService {
                 .title(postRequestDto.getTitle())
                 .content(postRequestDto.getContent())
                 .author(nickname)
-                .images(postRequestDto.getImages())
                 .member(member)
                 .build();
         postRepository.save(post);
@@ -61,7 +60,6 @@ public class PostService {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .author(post.getAuthor())
-                .images(post.getImages())
                 .comments(getCommentList(post))
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
@@ -75,7 +73,7 @@ public class PostService {
         return PostListResponseDto.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
-                .thumbnailUrl(post.getImages())
+                .thumbnailUrl("URL")
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
                 .createdYear(post.getCreatedYear())

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -49,7 +49,7 @@ public class PostService {
 
         List<CommentResponseDto> commentList = new ArrayList<>();
         for (Comment comment : post.getComments()) {
-            commentList.add(new CommentResponseDto(comment));
+            commentList.add(CommentService.toCommentResponseDto(comment, post.getMemberId(), post.getId()));
         }
         return commentList;
     }

--- a/src/main/java/com/shoesbox/domain/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/shoesbox/domain/post/dto/PostListResponseDto.java
@@ -9,7 +9,7 @@ import lombok.experimental.FieldDefaults;
 @Builder
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PostListResponseDto {
-    Long postId;
+    long postId;
     String title;
     String thumbnailUrl;
     String createdAt;

--- a/src/main/java/com/shoesbox/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/shoesbox/domain/post/dto/PostRequestDto.java
@@ -1,12 +1,10 @@
 package com.shoesbox.domain.post.dto;
 
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
-@ToString
 public class PostRequestDto {
     private String title;
     private String content;
-    private String images;
+    // private List<MultipartFile> imageFiles;
 }

--- a/src/main/java/com/shoesbox/global/config/SecurityConfig.java
+++ b/src/main/java/com/shoesbox/global/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import com.shoesbox.global.security.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -87,7 +86,7 @@ public class SecurityConfig {
 
                 .antMatchers("/").permitAll()
                 .antMatchers("/api/members/auth/**").permitAll()
-                .antMatchers(HttpMethod.GET, "/api/posts/**", "/api/comments/**").permitAll()
+                // .antMatchers(HttpMethod.GET, "/api/posts/**", "/api/comments/**").permitAll()
                 // .antMatchers(HttpMethod.POST, "/api/posts/**").hasAnyAuthority("ROLE_USER")
 
                 // 나머지는 전부 인증 필요


### PR DESCRIPTION
## 작업 목적

- 리팩토링

<br>

## 주요 변경점

- DTO와 ENTITY 간 강한 결합을 최대한 줄임
- 함수의 인자 개수가 지나치게 많아지는 경우가 아니라면
- dto 객체 대신 내부의 값(불변)을 직접 전달하도록 변경
- 불필요한 로직 제거

<br>

## 리뷰 포인트

- DTO 혹은 엔티티 내부에서 서로를 참조하지 않고, 컨트롤러나 서비스 단계에서 변환하도록 함
- DTO 내부의 값이 너무 많은 경우가 아니라면 DTO가 아닌 값을 직접 서비스에 전달
- 불필요한 로직 제거
	- ex)Comment 엔티티 안에 이미 postId를 가지고 있는데 getPost().getId()를 호출하는 등

<br>

close #25
