### PR TITLE
feat: Add get member info

### DIFF
--- a/src/main/java/com/shoesbox/domain/member/MemberController.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
         return ResponseHandler.ok(memberService.renewToken(tokenRequestDto));
     }
 
-    // 내 정보 가져오기
+    // 사용자 정보 가져오기(기본값: 현재 로그인한 사용자의 정보 반환)
     @GetMapping("/info")
     public ResponseEntity<Object> getMemberInfo(@RequestParam(value = "m", defaultValue = "0") long targetId) {
         long memberId = SecurityUtil.getCurrentMemberIdByLong();

--- a/src/main/java/com/shoesbox/domain/member/MemberController.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberController.java
@@ -35,9 +35,19 @@ public class MemberController {
     }
 
     // 내 정보 가져오기
-    @GetMapping("/myinfo")
-    public ResponseEntity<Object> getMyInfo() {
-        var userId = SecurityUtil.getCurrentMemberIdByLong();
-        return ResponseEntity.ok(memberService.getUserInfo(userId));
+    @GetMapping("/info")
+    public ResponseEntity<Object> getMemberInfo(@RequestParam(value = "m", defaultValue = "0") long targetId) {
+        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        if (targetId == 0L) {
+            return ResponseEntity.ok(memberService.getMemberInfo(memberId, memberId));
+        }
+        return ResponseEntity.ok(memberService.getMemberInfo(memberId, targetId));
+    }
+
+    // 로그아웃
+    @GetMapping("/logout")
+    public ResponseEntity<Object> logout() {
+        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        return ResponseEntity.ok(memberService.logout(memberId));
     }
 }

--- a/src/main/java/com/shoesbox/global/util/SecurityUtil.java
+++ b/src/main/java/com/shoesbox/global/util/SecurityUtil.java
@@ -1,11 +1,12 @@
 package com.shoesbox.global.util;
 
+import com.shoesbox.global.exception.runtime.UnAuthorizedException;
 import com.shoesbox.global.security.CustomUserDetails;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Slf4j
 @NoArgsConstructor
@@ -13,30 +14,35 @@ public class SecurityUtil {
     public static long getCurrentMemberIdByLong() {
         var principal = getPrincipal();
 
-        if (principal != null) {
-            return principal.getMemberId();
+        if (principal == null) {
+            throw new UnAuthorizedException("Security Context에 인증 정보가 없습니다.");
         }
 
-        return 0L;
+        return principal.getMemberId();
     }
 
     public static String getCurrentMemberNickname() {
         var principal = getPrincipal();
 
-        if (principal != null) {
-            return principal.getNickname();
+        if (principal == null) {
+            throw new UnAuthorizedException("Security Context에 인증 정보가 없습니다.");
         }
 
-        return null;
+        return principal.getNickname();
     }
 
     private static CustomUserDetails getPrincipal() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null) {
             log.debug("Security Context에 인증 정보가 없습니다.");
-            throw new UsernameNotFoundException(
+            throw new UnAuthorizedException(
                     "Security Context에 인증 정보가 없습니다.");
         }
-        return (CustomUserDetails) authentication.getPrincipal();
+
+        if (authentication.getPrincipal() instanceof UserDetails) {
+            return (CustomUserDetails) authentication.getPrincipal();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## 작업 목적

- 사용자 정보 가져오기

<br>

## 주요 변경점

- memberId를 query string으로 받아서 사용자 정보 반환
- 입력이 없을 시 기본값: 로그인한 사용자 정보를 반환
- 본인 계정일 경우에만 이메일 주소 반환
- 덤) 로그아웃 기능, 비로그인 상황에서의 예외 처리 추가

<br>

## 리뷰 포인트

-

<br>
