### PR TITLE
회원탈퇴 관련 버그 수정

### DIFF
--- a/src/main/java/com/shoesbox/domain/comment/CommentController.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentController.java
@@ -22,7 +22,7 @@ public class CommentController {
     @PostMapping("/{postId}")
     public ResponseEntity<Object> createComment(@PathVariable long postId,
                                                 @Valid @RequestBody CommentRequestDto commentRequestDto) {
-        long currentMemberId = SecurityUtil.getCurrentMemberIdByLong();
+        long currentMemberId = SecurityUtil.getCurrentMemberId();
         String currentMemberNickname = SecurityUtil.getCurrentMemberNickname();
         return ResponseHandler.ok(commentService.createComment(
                 currentMemberNickname, commentRequestDto.getContent(), currentMemberId, postId));
@@ -31,13 +31,13 @@ public class CommentController {
     @PutMapping("/{commentId}")
     public ResponseEntity<Object> updateComment(@PathVariable("commentId") long commentId,
                                                 @Valid @RequestBody CommentRequestDto commentRequestDto) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(commentService.updateComment(memberId, commentId, commentRequestDto));
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Object> deleteComment(@PathVariable("commentId") long commentId) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(commentService.deleteComment(memberId, commentId));
     }
 }

--- a/src/main/java/com/shoesbox/domain/member/Member.java
+++ b/src/main/java/com/shoesbox/domain/member/Member.java
@@ -68,7 +68,10 @@ public class Member extends BaseTimeEntity {
     // 친구들
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "fromMember",
             cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Friend> friends;
+    private List<Friend> fromMebers;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "toMember",
+            cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friend> toMembers;
 
     private int friendCount;
 

--- a/src/main/java/com/shoesbox/domain/member/Member.java
+++ b/src/main/java/com/shoesbox/domain/member/Member.java
@@ -2,6 +2,7 @@ package com.shoesbox.domain.member;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.shoesbox.domain.comment.Comment;
+import com.shoesbox.domain.friend.Friend;
 import com.shoesbox.domain.photo.Photo;
 import com.shoesbox.domain.post.Post;
 import com.shoesbox.global.common.BaseTimeEntity;
@@ -64,12 +65,19 @@ public class Member extends BaseTimeEntity {
 
     private int commentCount;
 
+    // 친구들
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "fromMember",
+            cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friend> friends;
+
+    private int friendCount;
+
     // 사진
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "member",
             cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Photo> photos;
 
-    public Member updateInfo(
+    public void updateInfo(
             String nickname,
             String profileImageUrl,
             String selfDescription) {
@@ -84,8 +92,6 @@ public class Member extends BaseTimeEntity {
         if (selfDescription != null) {
             this.selfDescription = selfDescription;
         }
-
-        return this;
     }
 
     public int addPostCount() {
@@ -102,5 +108,13 @@ public class Member extends BaseTimeEntity {
 
     public int minusCommentCount() {
         return --commentCount;
+    }
+
+    public int addFriendCount() {
+        return ++friendCount;
+    }
+
+    public int minusFriendCount() {
+        return --friendCount;
     }
 }

--- a/src/main/java/com/shoesbox/domain/member/MemberController.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberController.java
@@ -48,7 +48,8 @@ public class MemberController {
 
     // 회원 정보 수정
     @PatchMapping("/info")
-    public ResponseEntity<Object> updateMemberInfo(@RequestParam(value = "m", defaultValue = "0") long targetId, MemberInfoUpdateDto memberInfoUpdateDto) {
+    public ResponseEntity<Object> updateMemberInfo(@RequestParam(value = "m",
+            defaultValue = "0") long targetId, MemberInfoUpdateDto memberInfoUpdateDto) {
         long memberId = SecurityUtil.getCurrentMemberIdByLong();
         if (memberId != targetId) {
             throw new UnAuthorizedException("수정 권한이 없습니다.");
@@ -64,7 +65,7 @@ public class MemberController {
     }
 
     // 회원 탈퇴
-    @PostMapping("/delete")
+    @DeleteMapping("/delete")
     public ResponseEntity<Object> deleteAccount(@RequestParam(value = "m") long targetId) {
         long currentMemberId = SecurityUtil.getCurrentMemberIdByLong();
         if (currentMemberId != targetId) {

--- a/src/main/java/com/shoesbox/domain/member/MemberController.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberController.java
@@ -39,7 +39,7 @@ public class MemberController {
     // 회원 정보 가져오기(기본값: 현재 로그인한 사용자의 정보 반환)
     @GetMapping("/info")
     public ResponseEntity<Object> getMemberInfo(@RequestParam(value = "m", defaultValue = "0") long targetId) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         if (targetId == 0L) {
             return ResponseEntity.ok(memberService.getMemberInfo(memberId, memberId));
         }
@@ -50,7 +50,7 @@ public class MemberController {
     @PatchMapping("/info")
     public ResponseEntity<Object> updateMemberInfo(@RequestParam(value = "m",
             defaultValue = "0") long targetId, MemberInfoUpdateDto memberInfoUpdateDto) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         if (memberId != targetId) {
             throw new UnAuthorizedException("수정 권한이 없습니다.");
         }
@@ -60,14 +60,14 @@ public class MemberController {
     // 로그아웃
     @GetMapping("/logout")
     public ResponseEntity<Object> logout() {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(memberService.logout(memberId));
     }
 
     // 회원 탈퇴
     @DeleteMapping("/delete")
     public ResponseEntity<Object> deleteAccount(@RequestParam(value = "m") long targetId) {
-        long currentMemberId = SecurityUtil.getCurrentMemberIdByLong();
+        long currentMemberId = SecurityUtil.getCurrentMemberId();
         if (currentMemberId != targetId) {
             throw new UnAuthorizedException("본인의 memberId가 아닙니다.");
         }

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -21,7 +21,7 @@ public class PostController {
     // 생성
     @PostMapping
     public ResponseEntity<Object> createPost(PostRequestDto postRequestDto) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         String nickname = SecurityUtil.getCurrentMemberNickname();
         return ResponseHandler.ok(postService.createPost(nickname, memberId, postRequestDto));
     }
@@ -34,7 +34,7 @@ public class PostController {
             @RequestParam(value = "y", defaultValue = "0", required = false) int year,
             @RequestParam(value = "m", defaultValue = "0", required = false) int month) {
         if (memberId == 0) {
-            memberId = SecurityUtil.getCurrentMemberIdByLong();
+            memberId = SecurityUtil.getCurrentMemberId();
         }
 
         if (year == 0) {
@@ -51,21 +51,21 @@ public class PostController {
     // 상세 조회
     @GetMapping("/{postId}")
     public ResponseEntity<Object> getPost(@PathVariable long postId) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(postService.getPost(memberId, postId));
     }
 
     // 수정
     @PutMapping("/{postId}")
     public ResponseEntity<Object> updatePost(@PathVariable long postId, @RequestBody PostRequestDto postRequestDto) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(postService.updatePost(memberId, postId, postRequestDto));
     }
 
     // 삭제
     @DeleteMapping("/{postId}")
     public ResponseEntity<Object> deletePost(@PathVariable long postId) {
-        long memberId = SecurityUtil.getCurrentMemberIdByLong();
+        long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(postService.deletePost(memberId, postId));
     }
 

--- a/src/main/java/com/shoesbox/global/util/SecurityUtil.java
+++ b/src/main/java/com/shoesbox/global/util/SecurityUtil.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Slf4j
 @NoArgsConstructor
 public class SecurityUtil {
-    public static long getCurrentMemberIdByLong() {
+    public static long getCurrentMemberId() {
         var principal = getPrincipal();
 
         if (principal == null) {


### PR DESCRIPTION
## 작업 목적

- 회원탈퇴 api 버그 수정

<br>

## 주요 변경점

- MemberController.deleteAccount()의 http method를 POST->DELETE로 변경
- Member 엔티티에 Friend 엔티티와의 일대다 연관관계 매핑 추가
- SecurityUtil.getCurrentMemberIdByLong() 메서드명 변경 -> SecurityUtil.getCurrentMemberId()

<br>

## 리뷰 포인트

-

<br>

close #55