### PR TITLE
feature : s3 상의 이미지 수정 및 삭제

### DIFF
--- a/src/main/java/com/shoesbox/domain/photo/PhotoRepository.java
+++ b/src/main/java/com/shoesbox/domain/photo/PhotoRepository.java
@@ -2,6 +2,8 @@ package com.shoesbox.domain.photo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PhotoRepository extends JpaRepository<Photo, Long> {
+import java.util.List;
 
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> deleteAllByPostId(long postId);
 }

--- a/src/main/java/com/shoesbox/domain/photo/S3Service.java
+++ b/src/main/java/com/shoesbox/domain/photo/S3Service.java
@@ -48,6 +48,8 @@ public class S3Service {
                 .build();
     }
 
+
+    // 이미지 업로드
     public String uploadImage(MultipartFile file) {
         // 파일 이름 받아오기
         String fileName = Objects.requireNonNull(file.getOriginalFilename()).toLowerCase();
@@ -80,4 +82,14 @@ public class S3Service {
 
         return s3Client.getUrl(bucket, fileName).toString();    ///url string 리턴
     }
+
+    // 파일 삭제
+    public void deleteObjectByImageUrl(String imageUrl) {
+        // split을 통해 나누고 나눈 length에서 1을 빼서 마지막 값(파일명)을 사용함.
+        String sourceKey = imageUrl.split("/")[imageUrl.split("/").length - 1];
+        // 소스키로 s3에서 삭제
+        s3Client.deleteObject(bucket, sourceKey);
+    }
+
+
 }

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -68,5 +68,4 @@ public class PostController {
         long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(postService.deletePost(memberId, postId));
     }
-
 }

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -57,7 +57,7 @@ public class PostController {
 
     // 수정
     @PutMapping("/{postId}")
-    public ResponseEntity<Object> updatePost(@PathVariable long postId, @RequestBody PostRequestDto postRequestDto) {
+    public ResponseEntity<Object> updatePost(@PathVariable long postId, PostRequestDto postRequestDto) {
         long memberId = SecurityUtil.getCurrentMemberId();
         return ResponseHandler.ok(postService.updatePost(memberId, postId, postRequestDto));
     }

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -31,7 +31,7 @@ public class PostService {
     // 생성
     @Transactional
     public long createPost(String nickname, long memberId, PostRequestDto postRequestDto) {
-        if (postRequestDto.getImageFiles().isEmpty() || postRequestDto.getImageFiles().get(0).isEmpty()) {
+        if (postRequestDto.getImageFiles() == null || postRequestDto.getImageFiles().isEmpty() || postRequestDto.getImageFiles().get(0).isEmpty()) {
             throw new IllegalArgumentException("이미지를 최소 1장 이상 첨부해야 합니다.");
         }
 
@@ -102,8 +102,8 @@ public class PostService {
     @Transactional
     public String deletePost(long myMemberId, long postId) {
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new PostNotFoundException("해당 게시물이 존재하지 않습니다.")
-        );
+                () -> new PostNotFoundException("해당 게시물이 존재하지 않습니다."));
+
         long memberId = post.getMemberId();
         if (myMemberId == memberId) {
             deletePhoto(post);
@@ -167,7 +167,7 @@ public class PostService {
     }
 
     private void createPhoto(List<MultipartFile> imageFiles, Post post, Member member) {
-        if (imageFiles.isEmpty() || imageFiles.get(0).isEmpty()) {
+        if (imageFiles == null || imageFiles.isEmpty() || imageFiles.get(0).isEmpty()) {
             throw new IllegalArgumentException("이미지를 최소 1장 이상 첨부해야 합니다.");
         }
 
@@ -189,16 +189,11 @@ public class PostService {
         }
     }
 
-
     private void deletePhoto(Post post) {
         // s3 버킷에서 기존 이미지 삭제
         for (var photo : post.getPhotos()) {
             s3Service.deleteObjectByImageUrl(photo.getUrl());
         }
-
         post.getPhotos().clear();
-
     }
-
-
 }

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -87,7 +87,10 @@ public class PostService {
         long memberId = post.getMemberId();
         if (myMemberId == memberId) {
             post.update(postRequestDto.getTitle(), postRequestDto.getContent());
-            createPhoto(postRequestDto.getImageFiles(), post, null);
+
+            deletePhoto(post);
+            createPhoto(postRequestDto.getImageFiles(), post, post.getMember());
+
             postRepository.save(post);
             return toPostResponseDto(post);
         } else {
@@ -103,6 +106,7 @@ public class PostService {
         );
         long memberId = post.getMemberId();
         if (myMemberId == memberId) {
+            deletePhoto(post);
             postRepository.deleteById(postId);
             return "게시물 삭제 성공";
         } else {
@@ -134,7 +138,7 @@ public class PostService {
                 .content(post.getContent())
                 .nickname(post.getNickname())
                 .memberId(post.getMemberId())
-                .imageUrls(urls)
+                .images(urls)
                 .comments(getCommentList(post))
                 .createdAt(post.getCreatedAt())
                 .modifiedAt(post.getModifiedAt())
@@ -184,4 +188,17 @@ public class PostService {
             post.getPhotos().addAll(photos);
         }
     }
+
+
+    private void deletePhoto(Post post) {
+        // s3 버킷에서 기존 이미지 삭제
+        for (var photo : post.getPhotos()) {
+            s3Service.deleteObjectByImageUrl(photo.getUrl());
+        }
+
+        post.getPhotos().clear();
+
+    }
+
+
 }

--- a/src/main/java/com/shoesbox/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/shoesbox/domain/post/dto/PostResponseDto.java
@@ -18,7 +18,7 @@ public class PostResponseDto {
     String nickname;
     long memberId;
     List<CommentResponseDto> comments;
-    List<String> imageUrls;
+    List<String> images;
     String createdAt;
     String modifiedAt;
     int createdYear;


### PR DESCRIPTION
- s3의 수정 기능은 생성과 삭제를 통해 구현했습니다.
- 삭제 기능이 추가되었습니다.

#58

## 작업 목적

- S3 상의 이미지 파일 수정 및 삭제

<br>

## 주요 변경점

- S3 서비스의 삭제 메소드 추가
- POST 서비스의 S3 상 이미지 삭제 메소드 추가
- POST 서비스의 수정 메소드에 S3 생성, 삭제 메소드 추가

<br>

## 리뷰 포인트

- POST 서비스 단의 S3 생성 및 삭제 위치
- 선영님의 요구에 맞추어 ResponseDto의 urls를 images로 변경했습니다.

<br>
