### PR TITLE
fix: Fix member info update without image file

### DIFF
--- a/src/main/java/com/shoesbox/domain/member/Member.java
+++ b/src/main/java/com/shoesbox/domain/member/Member.java
@@ -45,9 +45,6 @@ public class Member extends BaseTimeEntity {
     private String profileImageUrl;
     @Column
     @NotBlank
-    private String selfDescription;
-    @Column
-    @NotBlank
     @JsonIgnore
     private final String authority = "ROLE_USER";
 
@@ -82,18 +79,13 @@ public class Member extends BaseTimeEntity {
 
     public void updateInfo(
             String nickname,
-            String profileImageUrl,
-            String selfDescription) {
+            String profileImageUrl) {
         if (nickname != null) {
             this.nickname = nickname;
         }
 
         if (profileImageUrl != null) {
             this.profileImageUrl = profileImageUrl;
-        }
-
-        if (selfDescription != null) {
-            this.selfDescription = selfDescription;
         }
     }
 

--- a/src/main/java/com/shoesbox/domain/member/MemberController.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberController.java
@@ -48,8 +48,8 @@ public class MemberController {
 
     // 회원 정보 수정
     @PatchMapping("/info")
-    public ResponseEntity<Object> updateMemberInfo(@RequestParam(value = "m",
-            defaultValue = "0") long targetId, MemberInfoUpdateDto memberInfoUpdateDto) {
+    public ResponseEntity<Object> updateMemberInfo(
+            @RequestParam(value = "m", defaultValue = "0") long targetId, MemberInfoUpdateDto memberInfoUpdateDto) {
         long memberId = SecurityUtil.getCurrentMemberId();
         if (memberId != targetId) {
             throw new UnAuthorizedException("수정 권한이 없습니다.");

--- a/src/main/java/com/shoesbox/domain/member/MemberService.java
+++ b/src/main/java/com/shoesbox/domain/member/MemberService.java
@@ -100,9 +100,9 @@ public class MemberService {
                     .orElseThrow(() -> new UsernameNotFoundException("memberId: " + targetId + "는 존재하지 않습니다."));
 
             return MemberInfoResponseDto.builder()
+                    .memberId(targetId)
                     .nickname(targetMember.getNickname())
                     .profileImageUrl(targetMember.getProfileImageUrl())
-                    .selfDescription(targetMember.getSelfDescription())
                     .build();
         }
 
@@ -110,10 +110,10 @@ public class MemberService {
                 .orElseThrow(() -> new UsernameNotFoundException("memberId: " + memberId + "는 존재하지 않습니다."));
 
         return MemberInfoResponseDto.builder()
+                .memberId(memberId)
                 .nickname(currentMember.getNickname())
                 .email(currentMember.getEmail())
                 .profileImageUrl(currentMember.getProfileImageUrl())
-                .selfDescription(currentMember.getSelfDescription())
                 .build();
     }
 
@@ -122,18 +122,18 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new UsernameNotFoundException("memberId: " + memberId + "는 존재하지 않습니다."));
 
-        String savedUrl = null;
-        if (!memberInfoUpdateDto.getImageFile().isEmpty()) {
+        String savedUrl = member.getProfileImageUrl();
+        if (memberInfoUpdateDto.getImageFile() != null && !memberInfoUpdateDto.getImageFile().isEmpty()) {
             savedUrl = s3Service.uploadImage(memberInfoUpdateDto.getImageFile());
         }
 
-        member.updateInfo(memberInfoUpdateDto.getNickname(), savedUrl, memberInfoUpdateDto.getSelfDescription());
+        member.updateInfo(memberInfoUpdateDto.getNickname(), savedUrl);
 
         return MemberInfoResponseDto.builder()
+                .memberId(memberId)
                 .nickname(member.getNickname())
                 .email(member.getEmail())
                 .profileImageUrl(member.getProfileImageUrl())
-                .selfDescription(member.getSelfDescription())
                 .build();
     }
 
@@ -214,7 +214,6 @@ public class MemberService {
                 .password(bCryptPasswordEncoder.encode(signDto.getPassword()))
                 .nickname(signDto.getEmail().split("@")[0])
                 .profileImageUrl("https://i.ibb.co/N27FwdP/image.png")
-                .selfDescription("안녕하세요.")
                 .build();
     }
 }

--- a/src/main/java/com/shoesbox/domain/member/dto/MemberInfoResponseDto.java
+++ b/src/main/java/com/shoesbox/domain/member/dto/MemberInfoResponseDto.java
@@ -13,8 +13,8 @@ import lombok.extern.jackson.Jacksonized;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class MemberInfoResponseDto {
+    long memberId;
     String nickname;
     String email;
     String profileImageUrl;
-    String selfDescription;
 }

--- a/src/main/java/com/shoesbox/domain/member/dto/MemberInfoUpdateDto.java
+++ b/src/main/java/com/shoesbox/domain/member/dto/MemberInfoUpdateDto.java
@@ -15,6 +15,5 @@ import org.springframework.web.multipart.MultipartFile;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class MemberInfoUpdateDto {
     String nickname;
-    String selfDescription;
     MultipartFile imageFile;
 }


### PR DESCRIPTION
## 작업 목적

- 회원정보 변경 시 닉네임과 이미지 파일을 각각 변경 가능하도록 함

<br>

## 주요 변경점

- 이미지 파일이 없으면 닉네임 수정이 불가능한 버그 수정
	- 존재하지 않는 이미지 파일의 null체크 도중 문제 발생
- Member 엔티티 및 연관 dto에서 selfDescription 필드 삭제
	- 사용되지 않음

<br>

## 리뷰 포인트

-

<br>

close #62 