### PR TITLE
Feature/57 friend access

### DIFF
--- a/src/main/java/com/shoesbox/domain/comment/CommentController.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentController.java
@@ -16,7 +16,8 @@ public class CommentController {
 
     @GetMapping("/{postId}")
     public ResponseEntity<Object> readComment(@PathVariable long postId) {
-        return ResponseHandler.ok(commentService.readComment(postId));
+        long currentMemberId = SecurityUtil.getCurrentMemberId();
+        return ResponseHandler.ok(commentService.readComment(postId, currentMemberId));
     }
 
     @PostMapping("/{postId}")

--- a/src/main/java/com/shoesbox/domain/comment/CommentService.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentService.java
@@ -1,10 +1,12 @@
 package com.shoesbox.domain.comment;
 
+import com.shoesbox.domain.friend.FriendService;
 import com.shoesbox.domain.member.Member;
 import com.shoesbox.domain.post.Post;
 import com.shoesbox.domain.post.PostRepository;
 import com.shoesbox.global.exception.runtime.PostNotFoundException;
 import com.shoesbox.global.exception.runtime.UnAuthorizedException;
+import com.shoesbox.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,11 +20,20 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
+    private final FriendService friendService;
+
     @Transactional(readOnly = true)
     public List<CommentResponseDto> readComment(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(
                         () -> new PostNotFoundException("해당 게시글이 존재하지 않습니다."));
+
+        long currentMemberId = SecurityUtil.getCurrentMemberId();
+        long authorId = post.getMemberId();
+
+        if(!friendService.isFriend(authorId, currentMemberId)){
+            throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");
+        }
 
         var comments = post.getComments();
         List<CommentResponseDto> commentList = new ArrayList<>();
@@ -43,10 +54,15 @@ public class CommentService {
                 .id(currentMemberId)
                 .build();
 
-        Post post = Post.builder()
-                .id(postId)
-                .member(member)
-                .build();
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new IllegalArgumentException("해당 게시물을 찾을 수 없습니다."));
+
+        long authorId = post.getMember().getId();
+        if(authorId != currentMemberId){
+            if(!friendService.isFriend(authorId, currentMemberId)){
+                throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");
+            }
+        }
 
         Comment comment = Comment.builder()
                 .nickname(currentMemberNickname)

--- a/src/main/java/com/shoesbox/domain/comment/CommentService.java
+++ b/src/main/java/com/shoesbox/domain/comment/CommentService.java
@@ -23,16 +23,17 @@ public class CommentService {
     private final FriendService friendService;
 
     @Transactional(readOnly = true)
-    public List<CommentResponseDto> readComment(Long postId) {
+    public List<CommentResponseDto> readComment(Long postId, long currentMemberId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(
                         () -> new PostNotFoundException("해당 게시글이 존재하지 않습니다."));
 
-        long currentMemberId = SecurityUtil.getCurrentMemberId();
         long authorId = post.getMemberId();
 
-        if(!friendService.isFriend(authorId, currentMemberId)){
-            throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");
+        if(authorId != currentMemberId){
+            if(!friendService.isFriend(authorId, currentMemberId)){
+                throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");
+            }
         }
 
         var comments = post.getComments();

--- a/src/main/java/com/shoesbox/domain/friend/FriendRepository.java
+++ b/src/main/java/com/shoesbox/domain/friend/FriendRepository.java
@@ -12,4 +12,6 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Friend findByToMemberIdAndFromMemberId(long toMember, long fromMember);
 
     Optional<Friend> findByFromMemberIdAndToMemberIdAndFriendState(long fromMemberId, long toMemberId, FriendState friendState);
+
+    boolean existsByFromMemberIdAndToMemberIdAndFriendState(long fromMemberId, long toMemberId, FriendState friendState);
 }

--- a/src/main/java/com/shoesbox/domain/friend/FriendService.java
+++ b/src/main/java/com/shoesbox/domain/friend/FriendService.java
@@ -158,4 +158,9 @@ public class FriendService {
             throw new IllegalArgumentException("이미 친구 요청중입니다.");
         }
     }
+
+    public boolean isFriend(long memberId, long currentMemberId){
+        return friendRepository.existsByFromMemberIdAndToMemberIdAndFriendState(memberId, currentMemberId, FriendState.FRIEND) ||
+                friendRepository.existsByFromMemberIdAndToMemberIdAndFriendState(currentMemberId, memberId, FriendState.FRIEND);
+    }
 }

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -33,8 +33,15 @@ public class PostController {
             @RequestParam(value = "id", defaultValue = "0", required = false) long memberId,
             @RequestParam(value = "y", defaultValue = "0", required = false) int year,
             @RequestParam(value = "m", defaultValue = "0", required = false) int month) {
-        if (memberId == 0) {
-            memberId = SecurityUtil.getCurrentMemberId();
+
+        long currentMemberId = SecurityUtil.getCurrentMemberId();
+
+        if (memberId == currentMemberId) {
+            memberId = currentMemberId;
+        } else {
+            if(!postService.isFriend(memberId, currentMemberId)){
+                throw new IllegalArgumentException("해당 회원과 친구 상태가 아닙니다.");
+            }
         }
 
         if (year == 0) {

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -38,7 +38,7 @@ public class PostController {
 
         long currentMemberId = SecurityUtil.getCurrentMemberId();
 
-        if (memberId == currentMemberId) {
+        if (memberId == 0) {
             memberId = currentMemberId;
         } else {
             if(!friendService.isFriend(memberId, currentMemberId)){

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -38,7 +38,7 @@ public class PostController {
 
         long currentMemberId = SecurityUtil.getCurrentMemberId();
 
-        if (memberId == 0) {
+        if (memberId == 0 || memberId == currentMemberId) {
             memberId = currentMemberId;
         } else {
             if(!friendService.isFriend(memberId, currentMemberId)){

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -1,5 +1,6 @@
 package com.shoesbox.domain.post;
 
+import com.shoesbox.domain.friend.FriendService;
 import com.shoesbox.domain.post.dto.PostRequestDto;
 import com.shoesbox.global.common.ResponseHandler;
 import com.shoesbox.global.util.SecurityUtil;
@@ -17,6 +18,7 @@ import java.time.LocalDate;
 @RequestMapping("/api/posts")
 public class PostController {
     private final PostService postService;
+    private final FriendService friendService;
 
     // 생성
     @PostMapping
@@ -39,7 +41,7 @@ public class PostController {
         if (memberId == currentMemberId) {
             memberId = currentMemberId;
         } else {
-            if(!postService.isFriend(memberId, currentMemberId)){
+            if(!friendService.isFriend(memberId, currentMemberId)){
                 throw new IllegalArgumentException("해당 회원과 친구 상태가 아닙니다.");
             }
         }

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -3,8 +3,7 @@ package com.shoesbox.domain.post;
 import com.shoesbox.domain.comment.Comment;
 import com.shoesbox.domain.comment.CommentResponseDto;
 import com.shoesbox.domain.comment.CommentService;
-import com.shoesbox.domain.friend.FriendRepository;
-import com.shoesbox.domain.friend.FriendState;
+import com.shoesbox.domain.friend.FriendService;
 import com.shoesbox.domain.member.Member;
 import com.shoesbox.domain.photo.Photo;
 import com.shoesbox.domain.photo.PhotoRepository;
@@ -28,7 +27,7 @@ import java.util.List;
 public class PostService {
     private final PostRepository postRepository;
     private final PhotoRepository photoRepository;
-    private final FriendRepository friendRepository;
+    private final FriendService friendService;
     private final S3Service s3Service;
 
     // 생성
@@ -70,7 +69,7 @@ public class PostService {
                 () -> new PostNotFoundException("해당 게시물을 찾을 수 없습니다.")
         );
         long memberId = post.getMemberId();
-        if (myMemberId == memberId || isFriend(myMemberId, memberId)) {
+        if (myMemberId == memberId || friendService.isFriend(myMemberId, memberId)) {
             return toPostResponseDto(post);
         } else {
             throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");
@@ -186,10 +185,5 @@ public class PostService {
             post.getPhotos().clear();
             post.getPhotos().addAll(photos);
         }
-    }
-
-    public boolean isFriend(long memberId, long currentMemberId){
-        return friendRepository.existsByFromMemberIdAndToMemberIdAndFriendState(memberId, currentMemberId, FriendState.FRIEND) ||
-                friendRepository.existsByFromMemberIdAndToMemberIdAndFriendState(currentMemberId, memberId, FriendState.FRIEND);
     }
 }

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -69,7 +69,9 @@ public class PostService {
                 () -> new PostNotFoundException("해당 게시물을 찾을 수 없습니다.")
         );
         long memberId = post.getMemberId();
-        if (myMemberId == memberId || friendService.isFriend(myMemberId, memberId)) {
+        if (myMemberId == memberId){
+            return toPostResponseDto(post);
+        } else if (friendService.isFriend(myMemberId, memberId)) {
             return toPostResponseDto(post);
         } else {
             throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -3,6 +3,8 @@ package com.shoesbox.domain.post;
 import com.shoesbox.domain.comment.Comment;
 import com.shoesbox.domain.comment.CommentResponseDto;
 import com.shoesbox.domain.comment.CommentService;
+import com.shoesbox.domain.friend.FriendRepository;
+import com.shoesbox.domain.friend.FriendState;
 import com.shoesbox.domain.member.Member;
 import com.shoesbox.domain.photo.Photo;
 import com.shoesbox.domain.photo.PhotoRepository;
@@ -26,6 +28,7 @@ import java.util.List;
 public class PostService {
     private final PostRepository postRepository;
     private final PhotoRepository photoRepository;
+    private final FriendRepository friendRepository;
     private final S3Service s3Service;
 
     // 생성
@@ -67,7 +70,7 @@ public class PostService {
                 () -> new PostNotFoundException("해당 게시물을 찾을 수 없습니다.")
         );
         long memberId = post.getMemberId();
-        if (myMemberId == memberId) {
+        if (myMemberId == memberId || isFriend(myMemberId, memberId)) {
             return toPostResponseDto(post);
         } else {
             throw new IllegalArgumentException("해당 게시물에 접근할 수 없습니다.");
@@ -183,5 +186,10 @@ public class PostService {
             post.getPhotos().clear();
             post.getPhotos().addAll(photos);
         }
+    }
+
+    public boolean isFriend(long memberId, long currentMemberId){
+        return friendRepository.existsByFromMemberIdAndToMemberIdAndFriendState(memberId, currentMemberId, FriendState.FRIEND) ||
+                friendRepository.existsByFromMemberIdAndToMemberIdAndFriendState(currentMemberId, memberId, FriendState.FRIEND);
     }
 }


### PR DESCRIPTION
## 작업 목적

- 게시글, 댓글 접근 시 친구관계 검증 추가

<br>

## 주요 변경점

- 전체 게시글 조회 시 controller에서 게시글 작성자와 현재 로그인한 유저가 본인인지, 혹은 친구 관계인지 검증
- 상세 게시글 조회 시 service에서 글 작성자와 현재 로그인한 유저가 본인인지, 혹은 친구 관계인지 검증
- 댓글 조회/작성시 해당 글 작성자와 로그인한 유저가 본인인지, 혹은 친구 관계인지 검증

<br>

## 리뷰 포인트

- 버그

<br>
