### PR TITLE
feat: 일기 목록 반환 형태 변경

### DIFF
--- a/src/main/java/com/shoesbox/domain/post/Post.java
+++ b/src/main/java/com/shoesbox/domain/post/Post.java
@@ -16,6 +16,8 @@ import java.util.List;
 @Getter
 @Entity
 @Table(name = "post")
+// TODO: 임시로  넣은 것. 제거해야 함!!
+@Setter
 public class Post extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -31,14 +33,20 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @Column(nullable = false)
-    private final int createdYear;
+    // @Column(nullable = false)
+    // private final LocalDate createdDate;
+    //
+    // @Column(nullable = false)
+    // private final int createdYear;
+    //
+    // @Column(nullable = false)
+    // private final int createdMonth;
+    //
+    // @Column(nullable = false)
+    // private final int createdDay;
 
     @Column(nullable = false)
-    private final int createdMonth;
-
-    @Column(nullable = false)
-    private final int createdDay;
+    private LocalDate createdDate;
 
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
@@ -58,11 +66,8 @@ public class Post extends BaseTimeEntity {
             cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Photo> photos;
 
-
     protected Post() {
-        this.createdYear = LocalDate.now().getYear();
-        this.createdMonth = LocalDate.now().getMonthValue();
-        this.createdDay = LocalDate.now().getDayOfMonth();
+        this.createdDate = LocalDate.now();
     }
 
     @Builder
@@ -79,5 +84,4 @@ public class Post extends BaseTimeEntity {
         this.title = title;
         this.content = content;
     }
-
 }

--- a/src/main/java/com/shoesbox/domain/post/Post.java
+++ b/src/main/java/com/shoesbox/domain/post/Post.java
@@ -33,18 +33,6 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private String nickname;
 
-    // @Column(nullable = false)
-    // private final LocalDate createdDate;
-    //
-    // @Column(nullable = false)
-    // private final int createdYear;
-    //
-    // @Column(nullable = false)
-    // private final int createdMonth;
-    //
-    // @Column(nullable = false)
-    // private final int createdDay;
-
     @Column(nullable = false)
     private LocalDate createdDate;
 

--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -26,10 +26,7 @@ public class PostController {
         long memberId = SecurityUtil.getCurrentMemberId();
         String nickname = SecurityUtil.getCurrentMemberNickname();
 
-        int year = LocalDate.now().getYear();
-        int month = LocalDate.now().getMonthValue();
-        int day = LocalDate.now().getDayOfMonth();
-        postService.postCreateCheck(postRequestDto, memberId, year, month, day);
+        postService.validatePostRequest(postRequestDto, memberId);
         return ResponseHandler.ok(postService.createPost(nickname, memberId, postRequestDto));
     }
 

--- a/src/main/java/com/shoesbox/domain/post/PostRepository.java
+++ b/src/main/java/com/shoesbox/domain/post/PostRepository.java
@@ -1,15 +1,12 @@
 package com.shoesbox.domain.post;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.time.LocalDate;
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    Optional<Post> findById(Long postId);
+    boolean existsByMemberIdAndCreatedDate(long memberId, LocalDate createdDate);
 
-    Page<Post> findByMemberIdAndCreatedYearAndCreatedMonth(Pageable pageable, Long memberId, int year, int month);
-
-    boolean existsByMemberIdAndCreatedYearAndCreatedMonthAndCreatedDay(long memberId, int year, int month, int day);
+    List<Post> findAllByMemberIdAndCreatedDateBetween(Long memberId, LocalDate firstDay, LocalDate lastDay);
 }

--- a/src/main/java/com/shoesbox/domain/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/shoesbox/domain/post/dto/PostListResponseDto.java
@@ -1,20 +1,20 @@
 package com.shoesbox.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PostListResponseDto {
     long postId;
-    String title;
     String thumbnailUrl;
-    String createdAt;
-    String modifiedAt;
-    int createdYear;
-    int createdMonth;
     int createdDay;
+    @JsonIgnore
+    LocalDate createdDate;
 }

--- a/src/main/java/com/shoesbox/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/shoesbox/domain/post/dto/PostResponseDto.java
@@ -15,13 +15,10 @@ public class PostResponseDto {
     Long postId;
     String title;
     String content;
-    String nickname;
     long memberId;
-    List<CommentResponseDto> comments;
-    List<String> images;
+    String nickname;
     String createdAt;
     String modifiedAt;
-    int createdYear;
-    int createdMonth;
-    int createdDay;
+    List<String> images;
+    List<CommentResponseDto> comments;
 }

--- a/src/main/java/com/shoesbox/global/security/CustomUserDetails.java
+++ b/src/main/java/com/shoesbox/global/security/CustomUserDetails.java
@@ -16,6 +16,7 @@ public class CustomUserDetails implements UserDetails, CredentialsContainer {
 
     private final String email;
     private String password;
+    private final String nickname;
     private final long memberId;
     private final Set<GrantedAuthority> authorities;
 
@@ -23,10 +24,12 @@ public class CustomUserDetails implements UserDetails, CredentialsContainer {
     private CustomUserDetails(
             String email,
             String password,
+            String nickname,
             long memberId,
             Collection<? extends GrantedAuthority> authorities) {
         this.email = email;
         this.password = (password == null) ? "" : password;
+        this.nickname = nickname;
         this.memberId = memberId;
         this.authorities = Collections.unmodifiableSet(sortAuthorities(authorities));
     }
@@ -76,7 +79,7 @@ public class CustomUserDetails implements UserDetails, CredentialsContainer {
     }
 
     public String getNickname() {
-        return this.email.split("@")[0];
+        return this.nickname;
     }
 
     @Override

--- a/src/main/java/com/shoesbox/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/shoesbox/global/security/CustomUserDetailsService.java
@@ -36,6 +36,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         return CustomUserDetails.builder()
                 .email(member.getEmail())
                 .password(member.getPassword())
+                .nickname(member.getNickname())
                 .memberId(member.getId())
                 .authorities(Collections.singleton(grantedAuthority))
                 .build();


### PR DESCRIPTION
## 작업 목적

- 일기(Post) 목록 반환 방식 변경:
	- 1일부터 마지막 날까지 반환하던 기존 방식은 프론트에서 추가 작업이 필요하기 때문에, 프론트의 작업 부담을 줄일 필요가 있었다.

<br>

## 주요 변경점

- 1일부터가 아닌, 첫 번째 주의 일요일부터 마지막 주의 토요일까지를 1달로 계산한다.
- 반환하는 날짜 수는 최소 28일, 최대 42일이다. (7의 배수)
- 어차피 1달씩 반환하는 api 특성상, 기존의 Pageable 객체는 불필요하다고 판단되어 제거했다.
- PostListResponseDto 안의 불필요한 값 제거

<br>

## 리뷰 포인트

- `java.time` 라이브러리 활용
	- 첫 번째 주의 일요일, 마지막 주의 토요일의 날짜 계산
	- 이번 달에 총 몇 주가 있는지 계산
	- Post 엔티티 안에 `LocalDate` 필드를 넣어 특정 기간 내에 작성한 글을 검색
	- 일기를 쓰지 않은 날은 날짜만 들어있는 더미 객체를 삽입

<br>

close #66 