### PR TITLE
Bugfix/81 image thumbnail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-oauth2-client
-     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client', version: '2.7.3'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client', version: '2.7.3'
 
     // https://mvnrepository.com/artifact/org.json/json
     implementation group: 'org.json', name: 'json', version: '20220320'
@@ -50,6 +50,10 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Thumbnail : https://mvnrepository.com/artifact/net.coobird/thumbnailator
+    implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/shoesbox/domain/photo/S3Service.java
+++ b/src/main/java/com/shoesbox/domain/photo/S3Service.java
@@ -23,22 +23,17 @@ import java.io.InputStream;
 import java.util.Objects;
 import java.util.UUID;
 
-
 @Slf4j
 @NoArgsConstructor
 @Service
 public class S3Service {
     private AmazonS3 s3Client;
-
     @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
-
     @Value("${cloud.aws.credentials.secretkey}")
     private String secretKey;
-
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
-
     @Value("${cloud.aws.region.static}")
     private String region;
 
@@ -52,10 +47,8 @@ public class S3Service {
                 .build();
     }
 
-
     // 이미지 업로드
     public String uploadImage(MultipartFile file) {
-
         // 파일 이름 받아오기
         String fileName = Objects.requireNonNull(file.getOriginalFilename()).toLowerCase();
 
@@ -68,7 +61,6 @@ public class S3Service {
 
         // 파일이름을 무작위 값으로 변경
         fileName = UUID.randomUUID() + fileExtension;
-
 
         ObjectMetadata objMeta = new ObjectMetadata();
         objMeta.setContentLength(file.getSize());
@@ -89,12 +81,12 @@ public class S3Service {
     public void deleteObjectByImageUrl(String imageUrl) {
         // split을 통해 나누고 나눈 length에서 1을 빼서 마지막 값(파일명)을 사용함.
         String sourceKey = imageUrl.split("/")[imageUrl.split("/").length - 1];
+
         // 소스키로 s3에서 삭제
         s3Client.deleteObject(bucket, sourceKey);
     }
 
     public String uploadThumbnail(MultipartFile mfile) throws IOException {
-
         // 파일 이름 받아오기
         String originalName = Objects.requireNonNull(mfile.getOriginalFilename()).toLowerCase();
         String fileName = originalName.substring(originalName.lastIndexOf("\\") + 1);
@@ -127,6 +119,5 @@ public class S3Service {
 
         outPutStream.delete();
         return s3Client.getUrl(bucket, saveName).toString();    ///url string 리턴
-
     }
 }

--- a/src/main/java/com/shoesbox/domain/photo/S3Service.java
+++ b/src/main/java/com/shoesbox/domain/photo/S3Service.java
@@ -66,7 +66,7 @@ public class S3Service {
             throw new IllegalArgumentException("bmp,jpg,jpeg,png 형식의 이미지 파일이 요구됨.");
         }
 
-        String fileExtension = fileName.substring(fileName.length() - 4);
+        String fileExtension = fileName.substring(fileName.lastIndexOf(".") + 1);
 
         // 파일이름을 무작위 값으로 변경
         fileName = UUID.randomUUID() + fileExtension;
@@ -101,7 +101,7 @@ public class S3Service {
         String originalName = Objects.requireNonNull(mfile.getOriginalFilename()).toLowerCase();
         String fileName = originalName.substring(originalName.lastIndexOf("\\") + 1);
         String uuid = UUID.randomUUID().toString();
-        String fileExtension = fileName.substring(fileName.length() - 4);
+        String fileExtension = fileName.substring(fileName.lastIndexOf(".") + 1);
         String saveName = "s_" + uuid + fileExtension;
 
         // 리사이징 할 파일 크기

--- a/src/main/java/com/shoesbox/domain/photo/S3Service.java
+++ b/src/main/java/com/shoesbox/domain/photo/S3Service.java
@@ -112,17 +112,7 @@ public class S3Service {
         Thumbnails.of(mfile.getInputStream())
                 .size(targetWidth, targetHeight)
                 .toFile(outPutStream);
-
-//        // Graphics2D 로 리사이징
-//        BufferedImage originalImage = ImageIO.read(mfile.getInputStream());
-//        BufferedImage resizedImage = new BufferedImage(targetWidth, targetHeight, originalImage.getType()); //BufferedImage.TYPE_INT_RGB
-//        Graphics2D graphics2D = resizedImage.createGraphics();
-//        graphics2D.drawImage(originalImage, 0, 0, targetWidth, targetHeight, null);
-//        graphics2D.dispose();
-//        // byte array를 File로 전환
-//        File outFile = new File(saveName);
-//        ImageIO.write(resizedImage, "jpg", outFile);
-
+        
         ObjectMetadata objMeta = new ObjectMetadata();
         objMeta.setContentLength(outPutStream.length());
         objMeta.setContentType(mfile.getContentType());

--- a/src/main/java/com/shoesbox/domain/photo/S3Service.java
+++ b/src/main/java/com/shoesbox/domain/photo/S3Service.java
@@ -112,7 +112,7 @@ public class S3Service {
         Thumbnails.of(mfile.getInputStream())
                 .size(targetWidth, targetHeight)
                 .toFile(outPutStream);
-        
+
         ObjectMetadata objMeta = new ObjectMetadata();
         objMeta.setContentLength(outPutStream.length());
         objMeta.setContentType(mfile.getContentType());
@@ -125,6 +125,7 @@ public class S3Service {
             throw new IllegalArgumentException("S3 Bucket 객체 업로드 실패.");
         }
 
+        outPutStream.delete();
         return s3Client.getUrl(bucket, saveName).toString();    ///url string 리턴
 
     }

--- a/src/main/java/com/shoesbox/domain/post/Post.java
+++ b/src/main/java/com/shoesbox/domain/post/Post.java
@@ -72,8 +72,9 @@ public class Post extends BaseTimeEntity {
         this.thumbnailUrl = thumbnailUrl;
     }
 
-    protected void update(String title, String content) {
+    protected void update(String title, String content, String thumbnailUrl) {
         this.title = title;
         this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
     }
 }

--- a/src/main/java/com/shoesbox/domain/post/Post.java
+++ b/src/main/java/com/shoesbox/domain/post/Post.java
@@ -36,6 +36,9 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate createdDate;
 
+    @Column(nullable = false)
+    private String thumbnailUrl;
+
     // 작성자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -59,13 +62,14 @@ public class Post extends BaseTimeEntity {
     }
 
     @Builder
-    private Post(long id, String title, String content, String nickname, Member member) {
+    private Post(long id, String title, String content, String nickname, Member member, String thumbnailUrl) {
         this();
         this.id = id;
         this.title = title;
         this.content = content;
         this.nickname = nickname;
         this.member = member;
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     protected void update(String title, String content) {

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -16,8 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDate;
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,17 +39,19 @@ public class PostService {
                 .nickname(nickname)
                 .build();
 
+        String thumbnailUrl = createThumbnail(postRequestDto.getImageFiles().get(0));
+
         // 게시글 생성
         Post post = Post.builder()
                 .title(postRequestDto.getTitle())
                 .content(postRequestDto.getContent())
                 .nickname(nickname)
                 .member(member)
+                .thumbnailUrl(thumbnailUrl)
                 .build();
         post = postRepository.save(post);
 
         // 이미지 업로드
-        createThumbnail(postRequestDto.getImageFiles().get(0), post, member);
         createPhoto(postRequestDto.getImageFiles(), post, member);
 
         return post.getId();
@@ -172,37 +174,27 @@ public class PostService {
     }
 
     private static PostListResponseDto toPostListResponseDto(Post post) {
-        String url = null;
-        if (post.getPhotos() != null && !post.getPhotos().isEmpty()) {
-            url = post.getPhotos().get(0).getUrl();
-        }
         return PostListResponseDto.builder()
                 .postId(post.getId())
-                // TODO: 썸네일 최적화 필요
-                .thumbnailUrl(url)
+                .thumbnailUrl(post.getThumbnailUrl())
                 .createdDate(post.getCreatedDate())
                 .createdDay(post.getCreatedDate().getDayOfMonth())
                 .build();
     }
 
 
-    private void createThumbnail(MultipartFile multipartFile, Post post, Member member) throws RuntimeException {
+    private String createThumbnail(MultipartFile multipartFile) {
 
         // 썸네일 업로드 및 맵핑
         String thumbnailUrl = null;
         try {
             thumbnailUrl = s3Service.uploadThumbnail(multipartFile);
         } catch (IOException e) {
+            // TODO: 2022-09-16 기본 썸네일로 대체해 업로드
             throw new RuntimeException("썸네일을 생성할 수 없습니다.");
         }
 
-        Photo photo = Photo.builder()
-                .url(thumbnailUrl)
-                .post(post)
-                .member((member == null) ? post.getMember() : member)
-                .build();
-        photoRepository.save(photo);
-
+        return thumbnailUrl;
     }
 
     private void createPhoto(List<MultipartFile> imageFiles, Post post, Member member) {

--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -119,9 +119,14 @@ public class PostService {
 
         long memberId = post.getMemberId();
         if (myMemberId == memberId) {
-            post.update(postRequestDto.getTitle(), postRequestDto.getContent());
-
+            // 기존 썸네일, 사진 삭제
+            s3Service.deleteObjectByImageUrl(post.getThumbnailUrl());
             deletePhoto(post);
+
+            // 썸네일 생성
+            String thumbnailUrl = createThumbnail(postRequestDto.getImageFiles().get(0));
+            post.update(postRequestDto.getTitle(), postRequestDto.getContent(), thumbnailUrl);
+
             createPhoto(postRequestDto.getImageFiles(), post, post.getMember());
 
             return toPostResponseDto(post);
@@ -139,6 +144,7 @@ public class PostService {
         long memberId = post.getMemberId();
         if (myMemberId == memberId) {
             deletePhoto(post);
+            s3Service.deleteObjectByImageUrl(post.getThumbnailUrl());
             postRepository.deleteById(postId);
             return "게시물 삭제 성공";
         } else {


### PR DESCRIPTION
## 작업 목적

- 썸네일 기능 전반의 수정이 포함됩니다.

<br>

## 주요 변경점

- 썸네일 생성 : (기존) Graphics2D -> (변경) Thumbnailator, 개선 포인트 - 썸네일의 화질 개선과 비율 유지, 유지보수 편리성
- 게시물 수정 시 썸네일 교체 
- 게시물 삭제 시 썸네일 이미지를 포함해 s3 상에서 모든 이미지들 삭제
- post entity에 thumbnailUrl 컬럼 추가

<br>

## 리뷰 포인트

- Graphics2d와 달리 Thumbnailator 를 통해 직관적이고 쉽게 더 좋은 성능의 썸네일을 생성할 수 있음을 확인해 볼 수 있습니다.

<br>
