### PR TITLE
fix: 마지막 날 계산이 잘못 이루어지던 문제 해결

### DIFF
--- a/src/main/java/com/shoesbox/domain/post/PostController.java
+++ b/src/main/java/com/shoesbox/domain/post/PostController.java
@@ -62,7 +62,7 @@ public class PostController {
         LocalDate firstMonday = firstDay.with(fieldISO, 1);
 
         // 찾으려는 달의 마지막 토요일의 날짜를 구한다
-        LocalDate lastDay = LocalDate.of(year, month, LocalDate.now().getMonth().maxLength());
+        LocalDate lastDay = LocalDate.of(year, month, firstDay.getMonth().maxLength());
         LocalDate lastSaturday = lastDay.with(fieldISO, 7);
 
         // 총 몇 주를 표시해야 하는지 계산한다.


### PR DESCRIPTION
## 작업 목적

- 31일이 일요일, 즉 한 주의 시작인 달은 마지막 주가 잘리는 현상이 발생
- 마지막 날을 계산할 때, 입력받은 값(month)이 아닌 현재(now)를 기준으로 마지막 날을 계산하고 있었다
- 즉, 이번 달에 30일까지밖에 없으면 31일이 포함된 다음 주가 잘려버린 것이다.

<br>

## 주요 변경점

- 이번 달을 기준으로 마지막 날을 계산하던 것을 입력 받은 달을 기준으로 계산하도록 변경

<br>

## 리뷰 포인트

-

<br>

close #83