### PR TITLE
fix: 전체글 보기 날짜 비교 버그 수정

### DIFF
--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -103,7 +103,8 @@ public class PostService {
             var today = firstMonday.plusDays(i);
             if (index < foundPosts.length) {
                 // 게시글의 작성일이 오늘과 일치할 경우 반환할 posts 배열에 대입
-                if (foundPosts[index].getCreatedDay() == today.getDayOfMonth()) {
+                if (foundPosts[index].getCreatedDay() == today.getDayOfMonth()
+                        && foundPosts[index].getCreatedMonth() == today.getMonthValue()) {
                     posts[i] = foundPosts[index];
                     ++index;
                     continue;


### PR DESCRIPTION
## 작업 목적

- 전체글 보기 도중 작성 월 비교를 하지 않던 문제 수정

<br>

## 주요 변경점

- 작성 날짜(day)가 같은 일기가 있을 경우 이전 달에도 출력하는 버그 수정

<br>

## 리뷰 포인트

-

<br>

close #66 