### PR TITLE
fix: 전체글 반환값 수정

### DIFF
--- a/src/main/java/com/shoesbox/domain/post/PostService.java
+++ b/src/main/java/com/shoesbox/domain/post/PostService.java
@@ -103,8 +103,7 @@ public class PostService {
             var today = firstMonday.plusDays(i);
             if (index < foundPosts.length) {
                 // 게시글의 작성일이 오늘과 일치할 경우 반환할 posts 배열에 대입
-                if (foundPosts[index].getCreatedDay() == today.getDayOfMonth()
-                        && foundPosts[index].getCreatedMonth() == today.getMonthValue()) {
+                if (foundPosts[index].getDate().isEqual(today)) {
                     posts[i] = foundPosts[index];
                     ++index;
                     continue;
@@ -115,6 +114,7 @@ public class PostService {
             posts[i] = PostResponseListDto.builder()
                                           .postId(0)
                                           .thumbnailUrl(null)
+                                          .createdYear(today.getYear())
                                           .createdMonth(today.getMonthValue())
                                           .createdDay(today.getDayOfMonth())
                                           .build();
@@ -217,8 +217,10 @@ public class PostService {
         return PostResponseListDto.builder()
                                   .postId(post.getId())
                                   .thumbnailUrl(post.getThumbnailUrl())
+                                  .createdYear(post.getDate().getYear())
                                   .createdMonth(post.getDate().getMonthValue())
                                   .createdDay(post.getDate().getDayOfMonth())
+                                  .date(post.getDate())
                                   .build();
     }
 

--- a/src/main/java/com/shoesbox/domain/post/dto/PostResponseListDto.java
+++ b/src/main/java/com/shoesbox/domain/post/dto/PostResponseListDto.java
@@ -6,13 +6,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 
+import java.time.LocalDate;
+
 @Getter
 @Builder
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class PostResponseListDto {
     long postId;
     String thumbnailUrl;
-    @JsonIgnore
+    int createdYear;
     int createdMonth;
     int createdDay;
+    @JsonIgnore
+    LocalDate date;
 }


### PR DESCRIPTION
## 작업 목적

- 전체글 반환 시 년도, 월을 전부 포함하는 것으로 변경

<br>

## 주요 변경점

- `PostResponseListDto`에 `createdYear`, `createdMonth`추가
- `PostResponseListDto`에 날짜 비교를 위한 `LocalDate` 객체 `date` 추가

<br>

## 리뷰 포인트

-

<br>
