### PR TITLE
feat: Add Daily Friend Post

### DIFF
--- a/src/main/java/com/shoesbox/domain/guest/GuestController.java
+++ b/src/main/java/com/shoesbox/domain/guest/GuestController.java
@@ -57,6 +57,9 @@ public class GuestController {
                     // 새 게스트 계정의 친구 관계 설정
                     guestService.makeFriendToGuest(FRIEND, signDto.getEmail(), FriendState.FRIEND);
                     guestService.makeFriendToGuest(REQUESTED_FRIEND, signDto.getEmail(), FriendState.REQUEST);
+
+                    // 친구 계정 중 오늘 날짜의 게시물이 없을 경우 생성
+                    guestService.makeFriendPost(FRIEND);
                 }
 
                 // 등록된 계정이 있을 경우, 반복문 종료 후 로그인 처리

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,4 @@ logging:
 default-images:
   thumbnail: https://i.ibb.co/Vj7Jrqx/default-thumbnail.webp
   profile: https://i.ibb.co/6wJFNWR/default-profile.webp
+  friendPostDefaultImage: https://postfiles.pstatic.net/MjAyMjA5MzBfODcg/MDAxNjY0NTIzOTQwODE3.crRGRRD_63yKgHb8IPnc9e6F-ewXXeZ1paMA-gPHt6cg.XhC-AUQH46m96VY2A8DETCC3tIQgVj_rd6QpeJDSX5Qg.PNG.cinyoung92/%EC%9C%8C%EB%A0%88%EC%8A%A4.png?type=w966


### PR DESCRIPTION
## 작업 목적

- 게스트계정으로 로그인 시 친구의 당일 게시글 생성

<br>

## 주요 변경점

- 친구 계정의 당일 포스트 존재여부 검사 후 없을 경우 새로 생성하는 부분 추가

<br>

## 리뷰 포인트

-

<br>
