### PR TITLE
feature : 게시물 길이 제한

### DIFF
--- a/src/main/java/com/shoesbox/domain/post/Post.java
+++ b/src/main/java/com/shoesbox/domain/post/Post.java
@@ -27,7 +27,8 @@ public class Post extends BaseTimeEntity {
     private Long id;
     @Column(nullable = false)
     private String title;
-    @Column(nullable = false)
+    @Lob
+    @Column(nullable = false, columnDefinition = "text")
     private String content;
     @Column(nullable = false)
     private String thumbnailUrl;


### PR DESCRIPTION
## 작업 목적

- 기존 일기장에 내용을 작성 시 String으로 저장되어  varchar(255) 타입으로 db에 적용이 됩니다. 긴 문자열이 삽입된 경우 500 error가 발생했습니다.
- 이에 db에 긴 문자열을 저장할 수 있도록 Lob annotation을 적용해 최대 65535 문자를 저장할 수 있도록 엔터티를 수정합니다.
- 컬럼에 포함된 contentType의 경우 text, longtext 등이 있으나 65535자 정도면 충분하다 여겨져 text 타입으로 작성했습니다.
**- 반드시 application.yml에서  spring.jpa.hibernate.ddl-auto 설정을 update로 변경해 주어야 db에 반영이 됩니다.**


<br>

## 주요 변경점

- post entity의 content에 contentType 추가 

<br>

## 리뷰 포인트

**- 반드시 application.yml에서  spring.jpa.hibernate.ddl-auto 설정을 update로 변경해 주어야 db에 반영이 됩니다.**

<br>

#124 