### PR TITLE
fix: Orientation 정보가 없는 이미지를 업로드할 수 없는 버그 수정

### DIFF
--- a/src/main/java/com/shoesbox/global/util/ImageUtil.java
+++ b/src/main/java/com/shoesbox/global/util/ImageUtil.java
@@ -78,19 +78,18 @@ public class ImageUtil {
 
     private int getOrientation(InputStream inputStream) {
         // 사진 방향 : 1~6, 1이 정상
-        int orientation;
+        int orientation = 1;
         try {
             // 메타데이터
             Metadata metadata = ImageMetadataReader.readMetadata(inputStream);
             // orientatino 가져오기
             Directory directory = metadata.getFirstDirectoryOfType(ExifIFD0Directory.class);
-            orientation = directory == null ? 1 : directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
+            if (directory != null && directory.containsTag(ExifIFD0Directory.TAG_ORIENTATION)) {
+                orientation = directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
+            }
             inputStream.close();
         } catch (IOException | ImageProcessingException | MetadataException e) {
             throw new ImageProcessException(IMAGE_ROTATE_FAILURE, e.getLocalizedMessage(), e);
-        }
-        if (orientation == 0) {
-            throw new ImageProcessException(IMAGE_ROTATE_FAILURE, "Image orientation is 0!");
         }
         return orientation;
     }


### PR DESCRIPTION
## 작업 목적

- 버그 수정

<br>

## 주요 변경점

- orientation이 없는 이미지도 업로드 가능하도록 수정

<br>

## 리뷰 포인트

-

<br>
